### PR TITLE
Possible extension for larger datasets - is it valid?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ OPTFLAGS    = -O -NDEBUG
 OPTFLAGS    = -g -pg
 INCFLAGS    = -I.
 CFLAGS      = $(OPTFLAGS) $(DFLAGS) $(INCFLAGS) -DBLOCK_SHARED_MEM_OPTIMIZATION=1
-NVCCFLAGS   = $(CFLAGS) --ptxas-options=-v
+NVCCFLAGS   = $(CFLAGS) --ptxas-options=-v -arch compute_11
 LDFLAGS     = $(OPTFLAGS)
 LIBS        =
 


### PR DESCRIPTION
Hi Serban, I emailed you yesterday about my experiences using your code for larger datasets. And the failure of the reduction when the number of threads exceeds the limit of 1024.

This is my attempt at avoiding this problem. Could you comment on it's validity?

As part of the solution, I used atomic expressions, which unfortunately require compute capability 1.1. There may be other ways to solve it.
